### PR TITLE
Add support for NFS backed config directories.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2.7-alpine
 MAINTAINER Sami Haahtinen <ressu@ressukka.net>
 
-ENV SICKGEAR_VERSION 0.11.11
+ENV SICKGEAR_VERSION 0.12.21
 
 # Download gosu and SickGear.
 RUN apk add --update \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,18 +4,17 @@ set -e
 # If we are called with default arguments, invoke SickGear with datadir and
 # setup the environment
 if [ "$1" = 'SickBeard.py' ]; then
+  APP_DATA_UIDGID="${APP_UID:=0}:${APP_GID:=0}"
   if [ ! -f ${APP_DATA}/config.ini ]; then
-    exec gosu ${APP_UID:=0}:${APP_GID:=0} cp /template/config.ini ${APP_DATA}/
+    exec gosu ${APP_DATA_UIDGID} cp /template/config.ini ${APP_DATA}/
   fi
-  CFG_DIR_UID=`ls -lnd "$APP_DATA" | awk 'NR==1 {print $3}'`
-  CFG_DIR_GID=`ls -lnd "$APP_DATA" | awk 'NR==1 {print $4}'`
-  if [ $APP_UID -ne $CFG_DIR_UID ] && [ $APP_GID -ne $CFG_DIR_GID ]; then
-    chown -R ${APP_UID:=0}:${APP_GID:=0} "$APP_DATA"
+  if [ $(stat -c "%u:%g" ${APP_DATA}) != "${APP_DATA_UIDGID}" ]; then
+    chown -R ${APP_DATA_UIDGID} "$APP_DATA"
   fi
 
   cd /opt/SickGear
 
-  exec gosu ${APP_UID:=0}:${APP_GID:=0} python "$@" --datadir=$APP_DATA
+  exec gosu ${APP_DATA_UIDGID} python "$@" --datadir=$APP_DATA
 fi
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,13 +5,17 @@ set -e
 # setup the environment
 if [ "$1" = 'SickBeard.py' ]; then
   if [ ! -f ${APP_DATA}/config.ini ]; then
-    cp /template/config.ini ${APP_DATA}/
+    exec gosu ${APP_UID:=0}:${APP_GID:=0} cp /template/config.ini ${APP_DATA}/
   fi
-  chown -R ${APP_UID:=0}:${APP_GID:=0} "$APP_DATA"
+  CFG_DIR_UID=`ls -lnd "$APP_DATA" | awk 'NR==1 {print $3}'`
+  CFG_DIR_GID=`ls -lnd "$APP_DATA" | awk 'NR==1 {print $4}'`
+  if [ $APP_UID -ne $CFG_DIR_UID ] && [ $APP_GID -ne $CFG_DIR_GID ]; then
+    chown -R ${APP_UID:=0}:${APP_GID:=0} "$APP_DATA"
+  fi
 
   cd /opt/SickGear
 
-  exec gosu $APP_UID:$APP_GID python "$@" --datadir=$APP_DATA
+  exec gosu ${APP_UID:=0}:${APP_GID:=0} python "$@" --datadir=$APP_DATA
 fi
 
 exec "$@"


### PR DESCRIPTION
The UID is impersonated when creating files, therefore, a check for correct permissions is done before attempting an operation that may fail e.g. a chown.