### PR TITLE
Hotfix stacksize

### DIFF
--- a/template/config.ini
+++ b/template/config.ini
@@ -2,3 +2,4 @@
 version_notify = 0
 root_dirs = 0|/tv
 tv_download_dir = /incoming
+stack_size = 327680


### PR DESCRIPTION
Make the docker config template use the new stack_size feature in SickGear to avoid crashes on Alpine when loading the Notifications settings page.